### PR TITLE
Adding workaround for threshold output

### DIFF
--- a/src/tests/vtkh/t_vtk-h_threshold.cpp
+++ b/src/tests/vtkh/t_vtk-h_threshold.cpp
@@ -43,7 +43,6 @@ TEST(vtkh_threshold, vtkh_serial_threshold)
   thresher.AddMapField("cell_data");
   thresher.Update();
   vtkh::DataSet *output = thresher.GetOutput();
-#if 0 
   vtkm::Bounds bounds = output->GetGlobalBounds();
 
   vtkm::rendering::Camera camera;
@@ -54,15 +53,10 @@ TEST(vtkh_threshold, vtkh_serial_threshold)
                                                           camera, 
                                                           *output, 
                                                           "threshold");  
-  // this is outputing a cell set type the 
-  // rendering infrastructure has not seen b
-  // before
-  output->PrintSummary(std::cout);
   vtkh::RayTracer tracer;
   tracer.SetInput(output);
   tracer.AddRender(render);
   tracer.SetField("cell_data"); 
   tracer.Update();
-#endif 
   delete output; 
 }

--- a/src/vtkh/filters/Threshold.cpp
+++ b/src/vtkh/filters/Threshold.cpp
@@ -1,11 +1,104 @@
 #include "Threshold.hpp"
 #include <vtkh/Error.hpp>
 
+
+#include <vtkm/cont/CellSetPermutation.h>
+#include <vtkm/cont/TryExecute.h>
 #include <vtkm/filter/Threshold.h>
+#include <vtkm/worklet/CellDeepCopy.h>
 
 namespace vtkh 
 {
 
+namespace detail
+{
+typedef vtkm::cont::CellSetPermutation<vtkm::cont::CellSetStructured<2>>
+  PermStructured2d; 
+
+typedef vtkm::cont::CellSetPermutation<vtkm::cont::CellSetStructured<3>>
+  PermStructured3d;
+
+typedef vtkm::cont::CellSetPermutation<vtkm::cont::CellSetExplicit<>>
+  PermExplicit;
+
+typedef  vtkm::cont::CellSetPermutation<vtkm::cont::CellSetSingleType<>>
+  PermExplicitSingle;
+//
+// Theshold outputs CellSetPermutations which cannot
+// be consumed by anything else in vtkm, so we need 
+// to explicitly do a deep copy and make the cell set 
+// explicit
+//
+template <typename CellSetType>
+struct DeepCopy
+{
+  const CellSetType &m_input;
+  vtkm::cont::CellSetExplicit<> &m_output;
+
+  DeepCopy(CellSetType &input,
+           vtkm::cont::CellSetExplicit<> &output)
+    : m_input(input)
+    , m_output(output)
+  {
+  }
+
+  template <typename Device>
+  bool operator()(Device device)
+  { 
+    m_output = vtkm::worklet::CellDeepCopy::Run(m_input, Device());
+    return true;
+  }
+};
+
+void StripPermutation(vtkm::cont::DataSet &data_set)
+{
+  vtkm::cont::DynamicCellSet cell_set = data_set.GetCellSet(); 
+  vtkm::cont::DataSet result;
+  vtkm::cont::CellSetExplicit<> explicit_cells;
+
+  if(cell_set.IsSameType(PermStructured2d()))
+  {
+    PermStructured2d perm = cell_set.Cast<PermStructured2d>();
+    DeepCopy<PermStructured2d> functor(perm, explicit_cells);
+    vtkm::cont::TryExecute(functor);
+  }
+  else if(cell_set.IsSameType(PermStructured3d()))
+  {
+    PermStructured3d perm = cell_set.Cast<PermStructured3d>();
+    DeepCopy<PermStructured3d> functor(perm, explicit_cells);
+    vtkm::cont::TryExecute(functor);
+  }
+  else if(cell_set.IsSameType(PermExplicit()))
+  {
+    PermExplicit perm = cell_set.Cast<PermExplicit>();
+    DeepCopy<PermExplicit> functor(perm, explicit_cells);
+    vtkm::cont::TryExecute(functor);
+  }
+  else if(cell_set.IsSameType(PermExplicitSingle()))
+  {
+    PermExplicitSingle perm = cell_set.Cast<PermExplicitSingle>();
+    DeepCopy<PermExplicitSingle> functor(perm, explicit_cells);
+    vtkm::cont::TryExecute(functor);
+  }
+  
+  result.AddCellSet(explicit_cells);
+
+  vtkm::Id num_coords = data_set.GetNumberOfCoordinateSystems();
+  for(vtkm::Id i = 0; i < num_coords; ++i)
+  {
+    result.AddCoordinateSystem(data_set.GetCoordinateSystem(i));
+  }
+
+  vtkm::Id num_fields = data_set.GetNumberOfFields();
+  for(vtkm::Id i = 0; i < num_fields; ++i)
+  {
+    result.AddField(data_set.GetField(i));
+  }
+   
+  data_set = result;
+}
+
+} // namespace detail
 
 Threshold::Threshold()
 {
@@ -88,7 +181,10 @@ void Threshold::DoExecute()
     {
       thresholder.MapFieldOntoOutput(res, dom.GetField(m_map_fields[f]));
     }
-    this->m_output->AddDomain(res.GetDataSet(), domain_id);
+
+    vtkm::cont::DataSet data_set = res.GetDataSet();
+    detail::StripPermutation(data_set);
+    this->m_output->AddDomain(data_set, domain_id);
     
   }
 }


### PR DESCRIPTION
VTK-m threshold outputs a cell set permutation. No worklet/filter/renderer can actually use type because it is not in the cell set list tags, so I am adding workaround code to copy the output to an explicit cell set.