### PR TITLE
updates for changes to vtk-m's filter API.

### DIFF
--- a/src/vtkh/filters/CleanGrid.cpp
+++ b/src/vtkh/filters/CleanGrid.cpp
@@ -37,13 +37,8 @@ CleanGrid::DoExecute()
     vtkm::Id domain_id;
     vtkm::cont::DataSet dom;
     this->m_input->GetDomain(i, dom, domain_id);
-
-    vtkm::filter::Result res = cleaner.Execute(dom);
-    for(size_t f = 0; f < m_map_fields.size(); ++f)
-    {
-      cleaner.MapFieldOntoOutput(res, dom.GetField(m_map_fields[f]));
-    }
-    this->m_output->AddDomain(res.GetDataSet(), domain_id);
+    auto dataset = cleaner.Execute(dom, this->GetFieldSelection());
+    this->m_output->AddDomain(dataset, domain_id);
   }
 
 }

--- a/src/vtkh/filters/Clip.cpp
+++ b/src/vtkh/filters/Clip.cpp
@@ -114,13 +114,8 @@ void Clip::DoExecute()
       }
     }
 
-    vtkm::filter::Result res = m_internals->m_clipper.Execute(dom);
-
-    for(size_t f = 0; f < m_map_fields.size(); ++f)
-    {
-      m_internals->m_clipper.MapFieldOntoOutput(res, dom.GetField(m_map_fields[f]));
-    }
-   data_set.AddDomain(res.GetDataSet(), domain_id);
+    auto dataset = m_internals->m_clipper.Execute(dom, this->GetFieldSelection());
+    data_set.AddDomain(dataset, domain_id);
   }
    
   CleanGrid cleaner; 

--- a/src/vtkh/filters/ClipField.cpp
+++ b/src/vtkh/filters/ClipField.cpp
@@ -64,13 +64,9 @@ void ClipField::DoExecute()
     vtkm::cont::DataSet dom;
     this->m_input->GetDomain(i, dom, domain_id);
 
-    vtkm::filter::Result res = clipper.Execute(dom, m_field_name);
-
-    for(size_t f = 0; f < m_map_fields.size(); ++f)
-    {
-      clipper.MapFieldOntoOutput(res, dom.GetField(m_map_fields[f]));
-    }
-    this->m_output->AddDomain(res.GetDataSet(), domain_id);
+    clipper.SetActiveField(m_field_name);
+    auto dataset = clipper.Execute(dom, this->GetFieldSelection());
+    this->m_output->AddDomain(dataset, domain_id);
   }
 }
 

--- a/src/vtkh/filters/Filter.cpp
+++ b/src/vtkh/filters/Filter.cpp
@@ -91,4 +91,17 @@ Filter::PropagateMetadata()
   m_output->SetCycle(m_input->GetCycle());
 }
 
+
+vtkm::filter::FieldSelection
+Filter::GetFieldSelection() const
+{
+  vtkm::filter::FieldSelection sel;
+  for (const auto& str : this->m_map_fields)
+  {
+    sel.AddField(str);
+  }
+  return sel;
+}
+
+
 } //namespace vtkh

--- a/src/vtkh/filters/Filter.hpp
+++ b/src/vtkh/filters/Filter.hpp
@@ -3,6 +3,7 @@
 
 #include <vtkh/vtkh.hpp>
 #include <vtkh/DataSet.hpp>
+#include <vtkm/filter/FieldSelection.h>
 
 namespace vtkh
 {
@@ -25,8 +26,14 @@ public:
 protected:
   virtual void DoExecute() = 0;
   virtual void PreExecute();
-
   virtual void PostExecute();
+
+  //@{
+  /// These are all temporary methods added to gets things building again
+  /// while we totally deprecate vtk-h compnents
+  ///
+  vtkm::filter::FieldSelection GetFieldSelection() const;
+  //@}
 
   std::vector<std::string> m_map_fields;
 

--- a/src/vtkh/filters/MarchingCubes.cpp
+++ b/src/vtkh/filters/MarchingCubes.cpp
@@ -101,7 +101,8 @@ void MarchingCubes::DoExecute()
   vtkm::filter::MarchingCubes marcher;
 
   marcher.SetIsoValues(m_iso_values);
-  marcher.SetMergeDuplicatePoints(true); 
+  marcher.SetMergeDuplicatePoints(true);
+  marcher.SetActiveField(m_field_name);
   const int num_domains = this->m_input->GetNumberOfDomains(); 
   int valid = 0;
   for(int i = 0; i < num_domains; ++i)
@@ -119,12 +120,8 @@ void MarchingCubes::DoExecute()
       continue;
     }
     valid++;
-    vtkm::filter::Result res = marcher.Execute(dom, m_field_name);
-    for(size_t f = 0; f < m_map_fields.size(); ++f)
-    {
-      marcher.MapFieldOntoOutput(res, dom.GetField(m_map_fields[f]));
-    }
-    m_output->AddDomain(res.GetDataSet(), domain_id);
+    auto dataset = marcher.Execute(dom, this->GetFieldSelection());
+    m_output->AddDomain(dataset, domain_id);
   }
 
 }

--- a/src/vtkh/filters/PointAverage.cpp
+++ b/src/vtkh/filters/PointAverage.cpp
@@ -51,9 +51,9 @@ void PointAverage::DoExecute()
 
     vtkm::filter::PointAverage avg;
     avg.SetOutputFieldName(m_output_field_name);
-    vtkm::filter::Result res = avg.Execute(dom, m_field_name);
-    
-    m_output->AddDomain(res.GetDataSet(), domain_id);
+    avg.SetActiveField(m_field_name);
+    auto dataset = avg.Execute(dom);
+    m_output->AddDomain(dataset, domain_id);
   }
 }
 

--- a/src/vtkh/filters/Threshold.cpp
+++ b/src/vtkh/filters/Threshold.cpp
@@ -165,21 +165,14 @@ void Threshold::DoExecute()
   vtkm::filter::Threshold thresholder;
   thresholder.SetUpperThreshold(m_range.Max);
   thresholder.SetLowerThreshold(m_range.Min);
-
+  thresholder.SetActiveField(m_field_name);
   for(int i = 0; i < num_domains; ++i)
   {
     vtkm::Id domain_id;
     vtkm::cont::DataSet dom;
     this->m_input->GetDomain(i, dom, domain_id);
 
-    vtkm::filter::Result res = thresholder.Execute(dom, m_field_name);
-
-    for(size_t f = 0; f < m_map_fields.size(); ++f)
-    {
-      thresholder.MapFieldOntoOutput(res, dom.GetField(m_map_fields[f]));
-    }
-
-    vtkm::cont::DataSet data_set = res.GetDataSet();
+    auto data_set = thresholder.Execute(dom);
     detail::StripPermutation(data_set);
     temp_data.AddDomain(data_set, domain_id);
   }


### PR DESCRIPTION
This gets vtkh building again with vtk-m master.

This is just a quick fix to get things building again. Ultimately, we want to get rid of vtkh::DataSet and vtkh::Filters entirely.