### PR TITLE
Corrected parameter (Step size) type

### DIFF
--- a/src/vtkh/vtkm_filters/vtkmLagrangian.cpp
+++ b/src/vtkh/vtkm_filters/vtkmLagrangian.cpp
@@ -7,7 +7,7 @@ namespace vtkh
 vtkm::cont::DataSet
 vtkmLagrangian::Run(vtkm::cont::DataSet &input,
                          std::string field_name,
-                         int step_size,
+                         double step_size,
                          int write_frequency,
                          int rank,
                          int cust_res,

--- a/src/vtkh/vtkm_filters/vtkmLagrangian.hpp
+++ b/src/vtkh/vtkm_filters/vtkmLagrangian.hpp
@@ -11,7 +11,7 @@ class vtkmLagrangian
 public:
   vtkm::cont::DataSet Run(vtkm::cont::DataSet &input,
                           std::string field_name,
-                          int step_size,
+                          double step_size,
                           int write_frequency,
                           int rank,
                           int cust_res,


### PR DESCRIPTION
The vtkmLagrangian filter files had a step size parameter set as int. 
This prevented non-integer step size and needed to be fixed. 