### PR TITLE
Add ENABLE_SERIAL option, on by default.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,13 @@ option(BUILD_SHARED_LIBS  "Build shared libraries"    ON)
 option(ENABLE_TESTS       "Build tests"               ON)
 option(ENABLE_CUDA        "Enable CUDA Support"       OFF)
 option(ENABLE_MPI         "Build MPI Support"         ON)
+option(ENABLE_SERIAL      "Build serial (non-MPI) libraries"    ON)
+
+if(NOT ENABLE_SERIAL AND NOT ENABLE_MPI)
+  message(FATAL_ERROR "No libraries are built. "
+    "Please set ENABLE_SERIAL, ENABLE_MPI or both to ON")
+endif()
+
 
 if(ENABLE_CUDA AND BUILD_SHARED_LIBS)
   message(FATAL_ERROR "Static libraries are required when building with CUDA")
@@ -118,15 +125,17 @@ add_subdirectory(vtkh)
 
 #------------------------------------------------------------------------------
 # Add a interface target that makes it easier to depend on VTKh
-add_library(vtkh INTERFACE)
-target_link_libraries(vtkh INTERFACE
-                      vtkh_core
-                      vtkh_utils
-                      vtkh_filters
-                      vtkh_rendering)
+if (ENABLE_SERIAL)
+  add_library(vtkh INTERFACE)
+  target_link_libraries(vtkh INTERFACE
+                        vtkh_core
+                        vtkh_utils
+                        vtkh_filters
+                        vtkh_rendering)
 
-# Install libraries
-install(TARGETS vtkh EXPORT ${VTKh_EXPORT_NAME})
+  # Install libraries
+  install(TARGETS vtkh EXPORT ${VTKh_EXPORT_NAME})
+endif()
 
 if (ENABLE_MPI)
   add_library(vtkh_mpi INTERFACE)

--- a/src/tests/vtkh/CMakeLists.txt
+++ b/src/tests/vtkh/CMakeLists.txt
@@ -91,21 +91,23 @@ set(MPI_TESTS t_vtk-h_smoke_par
 ################################
 # Add main tests
 ################################
-message(STATUS "Adding vtk-h lib unit tests")
-foreach(TEST ${BASIC_TESTS})
-    if(ENABLE_CUDA)
-      add_cpp_test(TEST ${TEST} DEPENDS_ON vtkh cuda)
-      vtkm_add_target_information(${TEST} DEVICE_SOURCES ${TEST}.cpp)
-      set_target_properties(${TEST} PROPERTIES LINKER_LANGUAGE CUDA)
-    else()
-      add_cpp_test(TEST ${TEST} DEPENDS_ON vtkh)
+if (ENABLE_SERIAL)
+    message(STATUS "Adding vtk-h lib unit tests")
+    foreach(TEST ${BASIC_TESTS})
+        if(ENABLE_CUDA)
+          add_cpp_test(TEST ${TEST} DEPENDS_ON vtkh cuda)
+          vtkm_add_target_information(${TEST} DEVICE_SOURCES ${TEST}.cpp)
+          set_target_properties(${TEST} PROPERTIES LINKER_LANGUAGE CUDA)
+        else()
+          add_cpp_test(TEST ${TEST} DEPENDS_ON vtkh)
+        endif()
+    endforeach()
+    
+    if(CUDA_FOUND)
+      foreach(TEST ${CUDA_TESTS})
+          add_cpp_test(TEST ${TEST} DEPENDS_ON vtkh cuda)
+      endforeach()
     endif()
-endforeach()
-
-if(CUDA_FOUND)
-  foreach(TEST ${CUDA_TESTS})
-      add_cpp_test(TEST ${TEST} DEPENDS_ON vtkh cuda)
-  endforeach()
 endif()
 
 ################################

--- a/src/vtkh/CMakeLists.txt
+++ b/src/vtkh/CMakeLists.txt
@@ -31,24 +31,25 @@ if(ENABLE_OPENMP)
     list(APPEND vtkm_core_deps openmp)
 endif()
 
-
-# blt vtk dep, includes all of vtkm
-blt_add_library(
-  NAME vtkh_core
-  SOURCES ${vtkh_core_sources}
-  HEADERS ${vtkh_core_headers}
-  DEPENDS_ON ${vtkh_core_deps}
-  )
-
-  vtkm_add_target_information(vtkh_core DEVICE_SOURCES ${vtkh_core_sources})
-
-# Install libraries
-install(TARGETS vtkh_core
-  EXPORT ${VTKh_EXPORT_NAME}
-  ARCHIVE DESTINATION ${VTKh_INSTALL_LIB_DIR}
-  LIBRARY DESTINATION ${VTKh_INSTALL_LIB_DIR}
-  RUNTIME DESTINATION ${VTKh_INSTALL_BIN_DIR}
-)
+if (ENABLE_SERIAL)
+    # blt vtk dep, includes all of vtkm
+    blt_add_library(
+      NAME vtkh_core
+      SOURCES ${vtkh_core_sources}
+      HEADERS ${vtkh_core_headers}
+      DEPENDS_ON ${vtkh_core_deps}
+      )
+    
+    vtkm_add_target_information(vtkh_core DEVICE_SOURCES ${vtkh_core_sources})
+    
+    # Install libraries
+    install(TARGETS vtkh_core
+      EXPORT ${VTKh_EXPORT_NAME}
+      ARCHIVE DESTINATION ${VTKh_INSTALL_LIB_DIR}
+      LIBRARY DESTINATION ${VTKh_INSTALL_LIB_DIR}
+      RUNTIME DESTINATION ${VTKh_INSTALL_BIN_DIR}
+      )
+endif()
 
 # Install headers
 install(FILES ${vtkh_core_headers}

--- a/src/vtkh/filters/CMakeLists.txt
+++ b/src/vtkh/filters/CMakeLists.txt
@@ -64,53 +64,53 @@ set(vtkh_comm_filters_sources
   communication/MemStream.cpp
   )
 
-
-set(vtkh_filters_deps vtkh_core vtkh_utils vtkm_compiled_filters)
-
-if(CUDA_FOUND)
-    # triggers cuda compile
-    list(APPEND vtkh_filters_deps cuda)
+if (ENABLE_SERIAL)
+    set(vtkh_filters_deps vtkh_core vtkh_utils vtkm_compiled_filters)
+    
+    if(CUDA_FOUND)
+        # triggers cuda compile
+        list(APPEND vtkh_filters_deps cuda)
+    endif()
+    
+    if(ENABLE_OPENMP)
+        list(APPEND vtkh_filters_deps openmp)
+    endif()
+    
+    
+    blt_add_library(
+      NAME vtkh_filters
+      SOURCES ${vtkh_filters_sources} ${vtkh_comm_filters_sources}
+      HEADERS ${vtkh_filters_headers} ${vtkh_comm_filters_headers}
+      DEPENDS_ON ${vtkh_filters_deps}
+      )
+    
+    
+    if(ENABLE_OPENMP)
+        blt_add_target_compile_flags(TO vtkh_filters FLAGS "-DVTKH_USE_OPENMP")
+    endif()
+    
+    if(ENABLE_CUDA)
+        set_target_properties(vtkh_filters PROPERTIES LINKER_LANGUAGE CUDA)
+    endif()
+    vtkm_add_target_information(vtkh_filters DEVICE_SOURCES ${vtkh_filter_sources})
+    
+    # Install libraries
+    install(TARGETS vtkh_filters
+      EXPORT ${VTKh_EXPORT_NAME}
+      ARCHIVE DESTINATION ${VTKh_INSTALL_LIB_DIR}
+      LIBRARY DESTINATION ${VTKh_INSTALL_LIB_DIR}
+      RUNTIME DESTINATION ${VTKh_INSTALL_BIN_DIR}
+      )
+    
+    
+    # Install headers
+    install(FILES ${vtkh_filters_headers}
+      DESTINATION ${VTKh_INSTALL_INCLUDE_DIR}/vtkh/filters)
+    
+    # Install headers
+    install(FILES ${vtkh_comm_filters_headers}
+      DESTINATION ${VTKh_INSTALL_INCLUDE_DIR}/vtkh/filters/communication)
 endif()
-
-if(ENABLE_OPENMP)
-    list(APPEND vtkh_filters_deps openmp)
-endif()
-
-
-blt_add_library(
-  NAME vtkh_filters
-  SOURCES ${vtkh_filters_sources} ${vtkh_comm_filters_sources}
-  HEADERS ${vtkh_filters_headers} ${vtkh_comm_filters_headers}
-  DEPENDS_ON ${vtkh_filters_deps}
-  )
-
-
-if(ENABLE_OPENMP)
-    blt_add_target_compile_flags(TO vtkh_filters FLAGS "-DVTKH_USE_OPENMP")
-endif()
-
-if(ENABLE_CUDA)
-    set_target_properties(vtkh_filters PROPERTIES LINKER_LANGUAGE CUDA)
-endif()
-vtkm_add_target_information(vtkh_filters DEVICE_SOURCES ${vtkh_filter_sources})
-
-# Install libraries
-install(TARGETS vtkh_filters
-  EXPORT ${VTKh_EXPORT_NAME}
-  ARCHIVE DESTINATION ${VTKh_INSTALL_LIB_DIR}
-  LIBRARY DESTINATION ${VTKh_INSTALL_LIB_DIR}
-  RUNTIME DESTINATION ${VTKh_INSTALL_BIN_DIR}
-  )
-
-
-# Install headers
-install(FILES ${vtkh_filters_headers}
-  DESTINATION ${VTKh_INSTALL_INCLUDE_DIR}/vtkh/filters)
-
-# Install headers
-install(FILES ${vtkh_comm_filters_headers}
-  DESTINATION ${VTKh_INSTALL_INCLUDE_DIR}/vtkh/filters/communication)
-
 
 if (MPI_FOUND)
 

--- a/src/vtkh/rendering/CMakeLists.txt
+++ b/src/vtkh/rendering/CMakeLists.txt
@@ -43,7 +43,7 @@ if (ENABLE_SERIAL)
         list(APPEND vtkh_rendering_deps cuda)
     endif()
     
-    if(ENABLE_OPENMPJ)
+    if(ENABLE_OPENMP)
         list(APPEND vtkh_rendering_deps openmp)
     endif()
     

--- a/src/vtkh/rendering/CMakeLists.txt
+++ b/src/vtkh/rendering/CMakeLists.txt
@@ -35,44 +35,44 @@ set(vtkh_rendering_sources
   compositing/PartialCompositor.cpp
   )
 
-
-set(vtkh_rendering_deps vtkh_core vtkh_utils vtkh_filters)
-
-if(VTKm_CUDA_FOUND)
-    # triggers cuda compile
-    list(APPEND vtkh_rendering_deps cuda)
+if (ENABLE_SERIAL)
+    set(vtkh_rendering_deps vtkh_core vtkh_utils vtkh_filters)
+    
+    if(VTKm_CUDA_FOUND)
+        # triggers cuda compile
+        list(APPEND vtkh_rendering_deps cuda)
+    endif()
+    
+    if(ENABLE_OPENMPJ)
+        list(APPEND vtkh_rendering_deps openmp)
+    endif()
+    
+    blt_add_library(
+      NAME vtkh_rendering
+      SOURCES ${vtkh_rendering_sources}
+      HEADERS ${vtkh_rendering_headers}
+      DEPENDS_ON ${vtkh_rendering_deps}
+      )
+    
+    vtkm_add_target_information(vtkh_rendering DEVICE_SOURCES ${vtkh_rendering_sources})
+    
+    if(ENABLE_OPENMP)
+        blt_add_target_compile_flags(TO vtkh_rendering FLAGS "-DVTKH_USE_OPENMP")
+    endif()
+    
+    
+    # Install libraries
+    install(TARGETS vtkh_rendering
+      EXPORT ${VTKh_EXPORT_NAME}
+      ARCHIVE DESTINATION ${VTKh_INSTALL_LIB_DIR}
+      LIBRARY DESTINATION ${VTKh_INSTALL_LIB_DIR}
+      RUNTIME DESTINATION ${VTKh_INSTALL_BIN_DIR}
+      )
+    
+    # Install headers
+    install(FILES ${vtkh_rendering_headers}
+      DESTINATION ${VTKh_INSTALL_INCLUDE_DIR}/vtkh/rendering)
 endif()
-
-if(ENABLE_OPENMPJ)
-    list(APPEND vtkh_rendering_deps openmp)
-endif()
-
-blt_add_library(
-  NAME vtkh_rendering
-  SOURCES ${vtkh_rendering_sources}
-  HEADERS ${vtkh_rendering_headers}
-  DEPENDS_ON ${vtkh_rendering_deps}
-  )
-
-vtkm_add_target_information(vtkh_rendering DEVICE_SOURCES ${vtkh_rendering_sources})
-
-if(ENABLE_OPENMP)
-    blt_add_target_compile_flags(TO vtkh_rendering FLAGS "-DVTKH_USE_OPENMP")
-endif()
-
-
-# Install libraries
-install(TARGETS vtkh_rendering
-  EXPORT ${VTKh_EXPORT_NAME}
-  ARCHIVE DESTINATION ${VTKh_INSTALL_LIB_DIR}
-  LIBRARY DESTINATION ${VTKh_INSTALL_LIB_DIR}
-  RUNTIME DESTINATION ${VTKh_INSTALL_BIN_DIR}
-  )
-
-# Install headers
-install(FILES ${vtkh_rendering_headers}
-  DESTINATION ${VTKh_INSTALL_INCLUDE_DIR}/vtkh/rendering)
-
 
 #------------------------------------------------------------------------------
 # Handle parallel library

--- a/src/vtkh/utils/CMakeLists.txt
+++ b/src/vtkh/utils/CMakeLists.txt
@@ -17,42 +17,43 @@ set(vtkh_utils_sources
   )
 
 set(vtkh_utils_thirdparty_libs vtkm vtkh_lodepng)
-
-if(CUDA_FOUND)
-  list(APPEND vtkh_utils_thirdparty_libs cuda)
+if (ENABLE_SERIAL)    
+    if(CUDA_FOUND)
+      list(APPEND vtkh_utils_thirdparty_libs cuda)
+    endif()
+    
+    if(ENABLE_OPENMP)
+      list(APPEND vtkh_utils_thirdparty_libs openmp)
+    endif()
+    
+    if(ENABLE_OPENMP)
+        list(APPEND vtkh_utils_thirdparty_libs openmp)
+    endif()
+    
+    blt_add_library(
+      NAME vtkh_utils
+      SOURCES ${vtkh_utils_sources}
+      HEADERS ${vtkh_utils_headers}
+      DEPENDS_ON ${vtkh_utils_thirdparty_libs}
+      )
+    
+    if(ENABLE_OPENMP)
+        blt_add_target_compile_flags(TO vtkh_utils FLAGS "-DVTKH_USE_OPENMP")
+    endif()
+    
+    
+    # Install libraries
+    install(TARGETS vtkh_utils
+      EXPORT ${VTKh_EXPORT_NAME}
+      ARCHIVE DESTINATION ${VTKh_INSTALL_LIB_DIR}
+      LIBRARY DESTINATION ${VTKh_INSTALL_LIB_DIR}
+      RUNTIME DESTINATION ${VTKh_INSTALL_BIN_DIR}
+      )
+    
+    # Install headers
+    install(FILES ${vtkh_utils_headers}
+            DESTINATION ${VTKh_INSTALL_INCLUDE_DIR}/vtkh/utils)
 endif()
-
-if(ENABLE_OPENMP)
-  list(APPEND vtkh_utils_thirdparty_libs openmp)
-endif()
-
-if(ENABLE_OPENMP)
-    list(APPEND vtkh_utils_thirdparty_libs openmp)
-endif()
-
-blt_add_library(
-  NAME vtkh_utils
-  SOURCES ${vtkh_utils_sources}
-  HEADERS ${vtkh_utils_headers}
-  DEPENDS_ON ${vtkh_utils_thirdparty_libs}
-  )
-
-if(ENABLE_OPENMP)
-    blt_add_target_compile_flags(TO vtkh_utils FLAGS "-DVTKH_USE_OPENMP")
-endif()
-
-
-# Install libraries
-install(TARGETS vtkh_utils
-  EXPORT ${VTKh_EXPORT_NAME}
-  ARCHIVE DESTINATION ${VTKh_INSTALL_LIB_DIR}
-  LIBRARY DESTINATION ${VTKh_INSTALL_LIB_DIR}
-  RUNTIME DESTINATION ${VTKh_INSTALL_BIN_DIR}
-  )
-
-# Install headers
-install(FILES ${vtkh_utils_headers}
-        DESTINATION ${VTKh_INSTALL_INCLUDE_DIR}/vtkh/utils)
 
 if (MPI_FOUND)
 


### PR DESCRIPTION
This allows users to only build vtkh_mpi (by
setting ENABLE_SERIAL to off) to prevent issues
when building vtkh that links with a vtkm with MPI enabled.