### PR TITLE
correct the sins of the past

### DIFF
--- a/src/tests/vtkh/t_vtk-h_ghost_stripper.cpp
+++ b/src/tests/vtkh/t_vtk-h_ghost_stripper.cpp
@@ -70,3 +70,35 @@ TEST(vtkh_ghost_stripper, vtkh_ghost_stripper)
 
   delete stripped_output;
 }
+
+//----------------------------------------------------------------------------
+TEST(vtkh_ghost_stripper, vtkh_ghost_stripper_no_strip)
+{
+  vtkh::DataSet data_set;
+
+  const int base_size = 32;
+  const int num_blocks = 1;
+
+  for(int i = 0; i < num_blocks; ++i)
+  {
+    data_set.AddDomain(CreateTestData(i, num_blocks, base_size), i);
+  }
+
+  vtkm::Id before_cells = data_set.GetNumberOfCells();
+
+  vtkh::GhostStripper stripper;
+
+  stripper.SetInput(&data_set);
+  stripper.SetField("ghosts");
+  stripper.SetMinValue(0);
+  stripper.SetMaxValue(2);
+  stripper.AddMapField("point_data_Float64");
+  stripper.Update();
+
+  vtkh::DataSet *stripped_output = stripper.GetOutput();
+
+  vtkm::Id after_cells = stripped_output->GetNumberOfCells();
+
+  assert(before_cells == after_cells);
+  delete stripped_output;
+}


### PR DESCRIPTION
Ghost stripper did bad things. While testing with timings, I discovered that stripping ghosts took 22s on a 512^3 grid with 36 openmp threads due to atomic CAS contention. I reworked the code and its down to less than 300ms. 

Additionally I corrected the case where the data would be copied even if there was nothing that needed to be done.

fixes #135