### PR TITLE
fix 1d sampling bug

### DIFF
--- a/src/vtkh/filters/HistSampling.cpp
+++ b/src/vtkh/filters/HistSampling.cpp
@@ -283,6 +283,13 @@ void HistSampling::DoExecute()
   vtkm::cont::Field::Association assoc = input->GetFieldAssociation(m_field_name,
                                                                     valid_field);
 
+
+  vtkm::Id global_num_values = histogram.totalCount();
+  vtkm::cont:: ArrayHandle <vtkm::Id > globCounts = histogram.m_bins;
+
+  vtkm::cont::ArrayHandle <vtkm::Float32 > probArray;
+  probArray = detail::calculate_pdf(global_num_values, numberOfBins, m_sample_percent, globCounts);
+
   for(int i = 0; i < num_domains; ++i)
   {
     vtkm::Range range;
@@ -306,7 +313,6 @@ void HistSampling::DoExecute()
     //std::cout << "Statistics for CELL data:" << std::endl;
     //PrintStatInfo(statinfo);
 
-    vtkm::cont:: ArrayHandle <vtkm::Id > globCounts = histogram.m_bins;
 
     // start doing sampling
 
@@ -321,8 +327,7 @@ void HistSampling::DoExecute()
 
     vtkm::worklet::DispatcherMapField<detail::RandomGenerate>(seed).Invoke(randArray);
 
-    vtkm::cont::ArrayHandle <vtkm::Float32 > probArray;
-    probArray = detail::calculate_pdf(tot_points, numberOfBins, m_sample_percent, globCounts);
+    
 
     vtkm::cont::ArrayHandle <vtkm::UInt8> stencilBool;
     vtkm::worklet::DispatcherMapField<LookupWorklet>(LookupWorklet{numberOfBins,

--- a/src/vtkh/filters/Histogram.cpp
+++ b/src/vtkh/filters/Histogram.cpp
@@ -194,4 +194,17 @@ Histogram::HistogramResult::Print(std::ostream &out)
   out<<"total points: "<<sum<<"\n";
 }
 
+vtkm::Id
+Histogram::HistogramResult::totalCount()
+{
+  auto binPortal = m_bins.ReadPortal();
+  const int num_bins = m_bins.GetNumberOfValues();
+  vtkm::Id sum = 0;
+  for (vtkm::Id i = 0; i < num_bins; i++)
+  {
+    sum += binPortal.Get(i);
+  }
+  return sum;
+}
+
 } //  namespace vtkh

--- a/src/vtkh/filters/Histogram.hpp
+++ b/src/vtkh/filters/Histogram.hpp
@@ -24,6 +24,7 @@ public:
     vtkm::Range m_range;
     vtkm::Float64 m_bin_delta;
     void Print(std::ostream &out);
+    vtkm::Id totalCount();
   };
 
   HistogramResult Run(vtkh::DataSet &data_set, const std::string &field_name);


### PR DESCRIPTION
The previous version of 1d sampling was under sampling the data. The acceptance probability was previously calculated using only the number of points in each domain. It should be using the total global number of points. 