### PR TITLE
ScalarRenderer: add dummy images for ranks with no data

### DIFF
--- a/src/vtkh/rendering/ScalarRenderer.cpp
+++ b/src/vtkh/rendering/ScalarRenderer.cpp
@@ -1,6 +1,8 @@
 #include "ScalarRenderer.hpp"
 #include <vtkh/compositing/PayloadCompositor.hpp>
 
+#include <vtkh/vtkh.hpp>
+
 #include <vtkh/Logger.hpp>
 #include <vtkh/utils/vtkm_array_utils.hpp>
 #include <vtkh/utils/vtkm_dataset_info.hpp>
@@ -168,9 +170,10 @@ ScalarRenderer::DoExecute()
 
   //Assume rank 0 has data, pass details to ranks with empty domains (no data).
 #ifdef VTKH_PARALLEL
-  MPI_Bcast(bounds, 6, MPI_FLOAT, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&max_p, 1, MPI_INT, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&min_p, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Comm mpi_comm = MPI_Comm_f2c(vtkh::GetMPICommHandle());
+  MPI_Bcast(bounds, 6, MPI_FLOAT, 0, mpi_comm);
+  MPI_Bcast(&max_p, 1, MPI_INT, 0, mpi_comm);
+  MPI_Bcast(&min_p, 1, MPI_INT, 0, mpi_comm);
 #endif
   
   if(num_domains == 0)

--- a/src/vtkh/rendering/ScalarRenderer.cpp
+++ b/src/vtkh/rendering/ScalarRenderer.cpp
@@ -143,20 +143,27 @@ ScalarRenderer::DoExecute()
   float bounds[6]; 
   for(int dom = 0; dom < num_domains; ++dom)
   {
-    Result res = renderers[dom].Render(m_camera);
+    vtkm::cont::DataSet data_set;
+    vtkm::Id domain_id;
+    m_input->GetDomain(dom, data_set, domain_id);
+    if(data_set.GetCellSet().GetNumberOfCells())
+    {
+	
+      Result res = renderers[dom].Render(m_camera);
 
-    field_names = res.ScalarNames;
-    PayloadImage *pimage = Convert(res);
-    min_p = std::min(min_p, pimage->m_payload_bytes);
-    max_p = std::max(max_p, pimage->m_payload_bytes);
-    compositor.AddImage(*pimage);
-    bounds[0] = pimage->m_bounds.X.Min;
-    bounds[1] = pimage->m_bounds.X.Max;
-    bounds[2] = pimage->m_bounds.Y.Min;
-    bounds[3] = pimage->m_bounds.Y.Max;
-    bounds[4] = pimage->m_bounds.Z.Min;
-    bounds[5] = pimage->m_bounds.Z.Max;
-    delete pimage;
+      field_names = res.ScalarNames;
+      PayloadImage *pimage = Convert(res);
+      min_p = std::min(min_p, pimage->m_payload_bytes);
+      max_p = std::max(max_p, pimage->m_payload_bytes);
+      compositor.AddImage(*pimage);
+      bounds[0] = pimage->m_bounds.X.Min;
+      bounds[1] = pimage->m_bounds.X.Max;
+      bounds[2] = pimage->m_bounds.Y.Min;
+      bounds[3] = pimage->m_bounds.Y.Max;
+      bounds[4] = pimage->m_bounds.Z.Min;
+      bounds[5] = pimage->m_bounds.Z.Max;
+      delete pimage;
+    }
   }
 
   //Assume rank 0 has data, pass details to ranks with empty domains (no data).


### PR DESCRIPTION
Assumes rank 0 has data and passes the necessary info for dummy images on ranks with no data. 