### PR TITLE
Add ability to add comments to png images.

### DIFF
--- a/src/vtkh/compositing/Image.cpp
+++ b/src/vtkh/compositing/Image.cpp
@@ -6,12 +6,14 @@
 namespace vtkh
 {
 
-void Image::Save(std::string name)
+void Image::Save(const std::string &name,
+                 const std::vector<std::string> &comments)
 {
     PNGEncoder encoder;
     encoder.Encode(&m_pixels[0],
         m_bounds.X.Max - m_bounds.X.Min + 1,
-        m_bounds.Y.Max - m_bounds.Y.Min + 1);
+        m_bounds.Y.Max - m_bounds.Y.Min + 1,
+        comments);   
     encoder.Save(name);
 }
 

--- a/src/vtkh/compositing/Image.hpp
+++ b/src/vtkh/compositing/Image.hpp
@@ -311,7 +311,8 @@ struct VTKH_API Image
       return ss.str();
     }
 
-    void Save(std::string name);
+    void Save(const std::string &name,
+              const std::vector<std::string> &comments);
 };
 
 struct CompositeOrderSort

--- a/src/vtkh/rendering/Render.cpp
+++ b/src/vtkh/rendering/Render.cpp
@@ -123,6 +123,12 @@ Render::SetImageName(const std::string &name)
 }
 
 void
+Render::SetComments(const std::vector<std::string> &comments)
+{
+  m_comments = comments;
+}
+
+void
 Render::SetBackgroundColor(float bg_color[4])
 {
   m_bg_color.Components[0] = bg_color[0];
@@ -144,6 +150,12 @@ std::string
 Render::GetImageName() const
 {
   return m_image_name;
+}
+
+std::vector<std::string>
+Render::GetComments() const
+{
+  return m_comments;
 }
 
 vtkm::rendering::Color
@@ -259,7 +271,7 @@ Render::Save()
   int height = m_canvas.GetHeight();
   int width = m_canvas.GetWidth();
   PNGEncoder encoder;
-  encoder.Encode(color_buffer, width, height);
+  encoder.Encode(color_buffer, width, height, m_comments);
   encoder.Save(m_image_name + ".png");
 }
 

--- a/src/vtkh/rendering/Render.hpp
+++ b/src/vtkh/rendering/Render.hpp
@@ -31,6 +31,7 @@ public:
   vtkmCanvas&                     GetCanvas();
   const vtkm::rendering::Camera&  GetCamera() const;
   std::string                     GetImageName() const;
+  std::vector<std::string>        GetComments() const;
   vtkm::Bounds                    GetSceneBounds() const;
   vtkm::Int32                     GetHeight() const;
   vtkm::Int32                     GetWidth() const;
@@ -46,6 +47,7 @@ public:
   void                            SetSceneBounds(const vtkm::Bounds &bounds);
   void                            SetCamera(const vtkm::rendering::Camera &camera);
   void                            SetImageName(const std::string &name);
+  void                            SetComments(const std::vector<std::string> &comments);
   void                            SetBackgroundColor(float bg_color[4]);
   void                            SetForegroundColor(float fg_color[4]);
   void                            SetShadingOn(bool on);
@@ -58,6 +60,7 @@ public:
 protected:
   vtkm::rendering::Camera      m_camera;
   std::string                  m_image_name;
+  std::vector<std::string>     m_comments;
   vtkm::Bounds                 m_scene_bounds;
   vtkm::Int32                  m_width;
   vtkm::Int32                  m_height;

--- a/src/vtkh/rendering/Renderer.cpp
+++ b/src/vtkh/rendering/Renderer.cpp
@@ -4,7 +4,6 @@
 #include <vtkh/Logger.hpp>
 #include <vtkh/utils/vtkm_array_utils.hpp>
 #include <vtkh/utils/vtkm_dataset_info.hpp>
-#include <vtkh/utils/PNGEncoder.hpp>
 #include <vtkm/rendering/raytracing/Logger.h>
 
 namespace vtkh {

--- a/src/vtkh/rendering/ScalarRenderer.cpp
+++ b/src/vtkh/rendering/ScalarRenderer.cpp
@@ -6,7 +6,6 @@
 #include <vtkh/Logger.hpp>
 #include <vtkh/utils/vtkm_array_utils.hpp>
 #include <vtkh/utils/vtkm_dataset_info.hpp>
-#include <vtkh/utils/PNGEncoder.hpp>
 #include <vtkm/rendering/raytracing/Logger.h>
 #include <vtkm/rendering/ScalarRenderer.h>
 

--- a/src/vtkh/thirdparty_builtin/lodepng/lodepng.h
+++ b/src/vtkh/thirdparty_builtin/lodepng/lodepng.h
@@ -486,14 +486,14 @@ typedef struct LodePNGInfo
 } LodePNGInfo;
 
 /*init, cleanup and copy functions to use with this struct*/
-void lodepng_info_init(LodePNGInfo* info);
-void lodepng_info_cleanup(LodePNGInfo* info);
+void VTKH_API lodepng_info_init(LodePNGInfo* info);
+void VTKH_API lodepng_info_cleanup(LodePNGInfo* info);
 /*return value is error code (0 means no error)*/
-unsigned lodepng_info_copy(LodePNGInfo* dest, const LodePNGInfo* source);
+unsigned VTKH_API lodepng_info_copy(LodePNGInfo* dest, const LodePNGInfo* source);
 
 #ifdef LODEPNG_COMPILE_ANCILLARY_CHUNKS
-void lodepng_clear_text(LodePNGInfo* info); /*use this to clear the texts again after you filled them in*/
-unsigned lodepng_add_text(LodePNGInfo* info, const char* key, const char* str); /*push back both texts at once*/
+void VTKH_API lodepng_clear_text(LodePNGInfo* info); /*use this to clear the texts again after you filled them in*/
+unsigned VTKH_API lodepng_add_text(LodePNGInfo* info, const char* key, const char* str); /*push back both texts at once*/
 
 void lodepng_clear_itext(LodePNGInfo* info); /*use this to clear the itexts again after you filled them in*/
 unsigned lodepng_add_itext(LodePNGInfo* info, const char* key, const char* langtag,

--- a/src/vtkh/utils/PNGEncoder.cpp
+++ b/src/vtkh/utils/PNGEncoder.cpp
@@ -54,7 +54,7 @@ PNGEncoder::Encode(const unsigned char *rgba_in,
 
     if(error)
     {
-      std::cerr<<"lodepng_encode_memory failed\n";
+        std::cerr<<"lodepng_encode_memory failed\n";
     }
 }
 
@@ -101,7 +101,124 @@ PNGEncoder::Encode(const float *rgba_in,
 
     if(error)
     {
-      std::cerr<<"lodepng_encode_memory failed\n";
+        std::cerr<<"lodepng_encode_memory failed\n";
+    }
+}
+
+void
+PNGEncoder::Encode(const unsigned char *rgba_in,
+                   const int width,
+                   const int height,
+                   const std::vector<std::string> &comments)
+{
+    Cleanup();
+
+    // upside down relative to what lodepng wants
+    unsigned char *rgba_flip = new unsigned char[width * height *4];
+
+    for (int y=0; y<height; ++y)
+    {
+        memcpy(&(rgba_flip[y*width*4]),
+               &(rgba_in[(height-y-1)*width*4]),
+               width*4);
+    }
+ 
+    vtkh::LodePNGState state;
+    vtkh::lodepng_state_init(&state);
+    // use less aggressive compression
+    state.encoder.zlibsettings.btype = 2;
+    state.encoder.zlibsettings.use_lz77 = 0;
+    if(comments.size() % 2 != 0)
+    {
+        std::cerr<<"PNGEncoder::Encode comments missing value for the last key.\n";
+        std::cerr<<"Ignoring the last key.\n";
+    }
+    if(comments.size() > 1)
+    {
+        vtkh::lodepng_info_init(&state.info_png);
+        // Comments are in pairs with a key and a value, using
+        // comments.size()-1 ensures that we don't use the last
+        // comment if the length of the vector isn't a multiple of 2.
+        for (int i = 0; i < comments.size()-1; i += 2)
+            vtkh::lodepng_add_text(&state.info_png, comments[i].c_str(),
+                                                    comments[i+1].c_str());
+    }
+
+    unsigned error = lodepng_encode(&m_buffer,
+                                    &m_buffer_size,
+                                    &rgba_flip[0],
+                                    width,
+                                    height,
+                                    &state);
+
+    delete [] rgba_flip;
+
+    if(error)
+    {
+        std::cerr<<"lodepng_encode_memory failed\n";
+    }
+}
+
+void
+PNGEncoder::Encode(const float *rgba_in,
+                   const int width,
+                   const int height,
+                   const std::vector<std::string> &comments)
+{
+    Cleanup();
+
+    // upside down relative to what lodepng wants
+    unsigned char *rgba_flip = new unsigned char[width * height *4];
+
+
+    for(int x = 0; x < width; ++x)
+
+#ifdef VTKH_USE_OPENMP
+        #pragma omp parallel for
+#endif
+        for (int y = 0; y < height; ++y)
+        {
+            int inOffset = (y * width + x) * 4;
+            int outOffset = ((height - y - 1) * width + x) * 4;
+            rgba_flip[outOffset + 0] = (unsigned char)(rgba_in[inOffset + 0] * 255.f);
+            rgba_flip[outOffset + 1] = (unsigned char)(rgba_in[inOffset + 1] * 255.f);
+            rgba_flip[outOffset + 2] = (unsigned char)(rgba_in[inOffset + 2] * 255.f);
+            rgba_flip[outOffset + 3] = (unsigned char)(rgba_in[inOffset + 3] * 255.f);
+        }
+
+    vtkh::LodePNGState state;
+    vtkh::lodepng_state_init(&state);
+    // use less aggressive compression
+    state.encoder.zlibsettings.btype = 2;
+    state.encoder.zlibsettings.use_lz77 = 0;
+    if(comments.size() % 2 != 0)
+    {
+        std::cerr<<"PNGEncoder::Encode comments missing value for the last key.\n";
+        std::cerr<<"Ignoring the last key.\n";
+    }
+    if(comments.size() > 1)
+    {
+        vtkh:lodepng_info_init(&state.info_png);
+        // Comments are in pairs with a key and a value, using
+        // comments.size()-1 ensures that we don't use the last
+        // comment if the length of the vector isn't a multiple of 2.
+        for (int i = 0; i < comments.size()-1; i += 2)
+            vtkh::lodepng_add_text(&state.info_png, comments[i].c_str(),
+                                                    comments[i+1].c_str());
+    }
+
+    unsigned error = lodepng_encode(&m_buffer,
+                                    &m_buffer_size,
+                                    &rgba_flip[0],
+                                    width,
+                                    height,
+                                    &state);
+
+    delete [] rgba_flip;
+
+    if(error)
+    {
+        std::cerr<<"lodepng_encode_memory failed\n";
     }
 }
 
@@ -110,7 +227,7 @@ PNGEncoder::Save(const std::string &filename)
 {
     if(m_buffer == NULL)
     {
-      std::cerr<<"Save must be called after encode()\n";
+        std::cerr<<"Save must be called after encode()\n";
         /// we have a problem ...!
         return;
     }
@@ -120,7 +237,7 @@ PNGEncoder::Save(const std::string &filename)
                                        filename.c_str());
     if(error)
     {
-      std::cerr<<"Error saving PNG buffer to file: " << filename<<"\n";
+        std::cerr<<"Error saving PNG buffer to file: " << filename<<"\n";
     }
 }
 

--- a/src/vtkh/utils/PNGEncoder.hpp
+++ b/src/vtkh/utils/PNGEncoder.hpp
@@ -3,6 +3,7 @@
 
 #include <vtkh/vtkh_exports.h>
 #include <string>
+#include <vector>
 
 namespace vtkh
 {
@@ -19,6 +20,14 @@ public:
     void           Encode(const float *rgba_in,
                           const int width,
                           const int height);
+    void           Encode(const unsigned char *rgba_in,
+                          const int width,
+                          const int height,
+                          const std::vector<std::string> &comments);
+    void           Encode(const float *rgba_in,
+                          const int width,
+                          const int height,
+                          const std::vector<std::string> &comments);
     void           Save(const std::string &filename);
 
     void          *PngBuffer();


### PR DESCRIPTION
I added the ability to add comments to png images. The comments are visible in XV.

I added the ability to store comments to the built in PNGEncoder. I added 2 new Encode methods with an extra argument containing the comments. The comments consist of a key and a string. I went with a vector of strings. The number of strings needs to be a multiple of 2. Right now the existing Encode methods still need to exist. Ascent could be modified to use only the new ones.

I removed an unnecessary #include PNGEncoder.h from Renderer and ScalarRenderer since they weren't necessary.

I added Set/GetComments to Render as well as logic to pass them to PNGEncoder.

For compositor/Image, I added another Save method that took the comments in addition to the file name. This seemed like the more natural way to do it for that class.

I've tested this with Ascent running the lulesh proxie in serial. This hasn't been tested with other proxies or using Rover or in parallel.

Here is an image from the resulting file showing the comment in XV.

![xv_comments](https://user-images.githubusercontent.com/1102718/119194874-970bcd00-ba38-11eb-98f6-431997664560.png)

Since this is my first commit to vtk-h/ascent, I'm expecting a fair number of requests for changes.