### PR TITLE
Display VTKM_DIR for ccmake users

### DIFF
--- a/src/cmake/Setup3rdParty.cmake
+++ b/src/cmake/Setup3rdParty.cmake
@@ -71,5 +71,6 @@ if(VTKM_DIR)
     ################################
     include(cmake/thirdparty/SetupVTKm.cmake)
 else()
-    message(FATAL_ERROR "VTK-h requries VTK-m")
+    set(VTKM_DIR "" CACHE PATH "Path to VTK-m")
+    message(FATAL_ERROR "VTK-h requries VTK-m (Please set VTKM_DIR)")
 endif()


### PR DESCRIPTION
Calling `find_library` automatically populates VTKM_DIR if possible, but mostly make it appear into ccmake. Useful for beginners