### PR TITLE
Cast double -> float in vtkmPointTransform

### DIFF
--- a/src/vtkh/vtkm_filters/vtkmPointTransform.cpp
+++ b/src/vtkh/vtkm_filters/vtkmPointTransform.cpp
@@ -12,7 +12,15 @@ vtkmPointTransform::Run(vtkm::cont::DataSet &input,
 
   trans.SetChangeCoordinateSystem(true);
   trans.SetFieldsToPass(map_fields);
-  trans.SetTransform(transform);
+  vtkm::Matrix<vtkm::FloatDefault,4,4> default_mat;
+  for(int i = 0; i < 4; i++)
+  {
+    for(int j = 0; i < 4; j++)
+    {
+      default_mat[i][j] = static_cast<vtkm::FloatDefault>(transform[i][j]);
+    }
+  }
+  trans.SetTransform(default_mat);
 
   auto output = trans.Execute(input);
   return output;


### PR DESCRIPTION
VTK-H does not compile on my machine because of this. Have I done something wrong ? I'm using the recommanded VTK-M version

```
/home/gpotter/git/WarpX/vtk-h/src/vtkh/vtkm_filters/vtkmPointTransform.cpp: In member function ‘vtkm::cont::DataSet vtkh::vtkmPointTransform::Run(vtkm::cont::DataSet&, vtkm::Matrix<double, 4, 4>&, vtkm::filter::FieldSelection)’:
/home/gpotter/git/WarpX/vtk-h/src/vtkh/vtkm_filters/vtkmPointTransform.cpp:15:22: error: cannot convert ‘vtkm::Matrix<double, 4, 4>’ to ‘const vtkm::Matrix<float, 4, 4>&’
   15 |   trans.SetTransform(transform);
      |                      ^~~~~~~~~
      |                      |
      |                      vtkm::Matrix<double, 4, 4>
In file included from /home/gpotter/git/WarpX/vtk-m/install/include/vtkm-1.5/vtkm/filter/PointTransform.h:80,
                 from /home/gpotter/git/WarpX/vtk-h/src/vtkh/vtkm_filters/vtkmPointTransform.cpp:2:
```